### PR TITLE
add: 他ユーザーの過去の投稿一覧ページ

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,14 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[edit update destroy]
 
   def index
-    @q = Post.ransack(params[:q])
+    if params[:user_id]
+      # 特定のユーザーの投稿をフィルタリング
+      user_posts = Post.where(user_id: params[:user_id])
+      @q = user_posts.ransack(params[:q])
+    else
+      # 全ての投稿を検索対象とする
+      @q = Post.ransack(params[:q])
+    end
     @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
   end
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,12 @@
 <% content_for(:title, t('.title')) %>
 <div class="container px-5 pt-12 md:pt-24 pb-10 mx-auto">
-  <h1 class="text-lg sm:text-2xl font-bold my-10 text-center"><%= t('.title') %></h1>
+  <h1 class="text-lg sm:text-2xl font-bold my-10 text-center">
+    <% if params[:user_id] %>
+      <%= t('.user_posts_title') %>
+    <% else %>
+      <%= t('.title') %>
+    <% end %>
+  </h1>
   <%= render 'search_form', q: @q, url: posts_path %>
   <% if @posts.present? %>
     <div class="flex flex-wrap mt-10">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,7 +4,7 @@
   <div class="flex flex-col-reverse justify-center sm:flex-row">
     <div class="flex justify-center border border-gray-500 bg-white p-8 rounded-lg mt-10 sm:mt-0 sm:mr-20">
       <ul class="space-y-10">
-        <li><%= link_to '過去の投稿一覧', posted_posts_path %></li>
+        <li><%= link_to '過去の投稿一覧', user_posts_path(@user) %></li>
         <li><%= link_to 'いいね済み一覧', likes_posts_path %></li>
       </ul>
     </div>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -38,6 +38,8 @@ ja:
     create:
       success: ユーザー登録が完了しました
       failure: ユーザー登録に失敗しました
+    show:
+      title: プロフィールページ
   password_resets:
     new:
       title: パスワードリセット
@@ -50,6 +52,7 @@ ja:
   posts:
     index:
       title: 投稿一覧
+      user_posts_title: 過去の投稿一覧
     new:
       title: 投稿フォーム
     posted:
@@ -66,7 +69,6 @@ ja:
   profiles:
     show:
       title: マイページ
-      other_title: プロフィールページ
     edit:
       title: プロフィール設定
   header:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   root 'tops#index'
-  resources :users, only: %i[new create show]
+  resources :users, only: %i[new create show] do
+    resources :posts, only: [:index], on: :member
+  end
   resources :posts do
     resources :comments, only: %i[create destroy], shallow: true
     collection do


### PR DESCRIPTION
### 概要
他ユーザーの過去の投稿一覧ページを追加

### 内容
ログインユーザーが他ユーザーのプロフィールページから、そのユーザーの過去の投稿一覧に遷移できるようにする。