### PR TITLE
add: 組合せ一覧ページ

### DIFF
--- a/app/controllers/appetizers_controller.rb
+++ b/app/controllers/appetizers_controller.rb
@@ -1,6 +1,10 @@
 class AppetizersController < ApplicationController
   before_action :set_token, only: :create
 
+  def index
+    @appetizers = Appetizer.where(user_id: params[:user_id]).includes(:user).order(created_at: :desc).page(params[:page])
+  end
+
   def new
     @appetizer = Appetizer.new
     @selected_genres = AlcoholGenre.where(genre: ["ビール", "焼酎", "日本酒", "ウイスキー", "ブランデー", "ワイン", "梅酒", "サワー", "酎ハイ"])

--- a/app/views/appetizers/_appetizer.html.erb
+++ b/app/views/appetizers/_appetizer.html.erb
@@ -1,0 +1,23 @@
+<div class="w-full md:w-1/2 2xl:w-1/3 p-4">
+  <div class="border bg-amber-50 shadow-xl rounded-lg p-4">
+    <span class="text-sm"><%= l(appetizer.created_at, format: :long) %></span>
+    <div class="flex justify-between items-end mb-3">
+      <div class="w-3/4 font-bold">
+        <%= appetizer.name %>
+      </div>
+      <div class="w-1/4 text-end">
+        <%= link_to "詳細", appetizer_path(appetizer), class: 'font-bold bg-point rounded-[10px] hover:bg-yellow-400 px-3 py-1' %>
+      </div>
+    </div>
+    <div class="flex flex-col lg:flex-row">
+      <div class="flex">
+        <span class="border border-gray-500 bg-white rounded-[10px] text-sm text-gray-500 px-2 lg:mr-1"><%= appetizer.alcohol.name %></span>
+      </div>
+      <div class="flex">
+        <span class="border border-gray-500 bg-white rounded-[10px] text-sm text-gray-500 px-2 mr-1"><%= appetizer.base_ingredient.name %></span>
+        <span class="border border-gray-500 bg-white rounded-[10px] text-sm text-gray-500 px-2 mr-1"><%= appetizer.sub_ingredient.name %></span>
+        <span class="border border-gray-500 bg-white rounded-[10px] text-sm text-gray-500 px-2"><%= appetizer.accent_ingredient.name %></span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/appetizers/index.html.erb
+++ b/app/views/appetizers/index.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:title, t('.user_appetizers_title')) %>
+<div class="container px-5 pt-12 md:pt-24 pb-10 mx-auto">
+  <h1 class="text-lg sm:text-2xl font-bold my-10 text-center">
+    <%= t('.user_appetizers_title') %>
+  </h1>
+  <% if @appetizers.present? %>
+    <div class="flex flex-wrap mt-10">
+      <% @appetizers.each do |appetizer| %>
+        <%= render 'appetizer', appetizer: appetizer %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="flex justify-center">
+      組み合わせがありません
+    </div>
+  <% end %>
+  <div class="flex justify-center">
+    <% if @appetizers.total_pages > 1 %>
+      <%= paginate @appetizers %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/appetizers/show.html.erb
+++ b/app/views/appetizers/show.html.erb
@@ -12,7 +12,7 @@
       </div>
     <% end %>
     <div class="flex justify-center w-full md:w-1/2">
-      <%= link_to '組合せフォームに戻る', new_appetizer_path, class: 'bg-point font-bold hover:bg-yellow-400 shadow-xl my-10 rounded-full px-5 py-3' %>
+      <%= link_to "#{@appetizer.user.name}の組合せ一覧", user_appetizers_path(@appetizer.user), class: 'bg-point font-bold hover:bg-yellow-400 shadow-xl my-10 rounded-full px-5 py-3' %>
     </div>
   </div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -6,6 +6,7 @@
       <ul class="space-y-10">
         <li><%= link_to '過去の投稿一覧', posted_posts_path, class:'hover:text-yellow-400' %></li>
         <li><%= link_to 'いいね済み一覧', likes_posts_path, class:'hover:text-yellow-400' %></li>
+        <li><%= link_to 'AI組合せ一覧', user_appetizers_path(@user), class:'hover:text-yellow-400' %></li>
         <li><%= link_to 'プロフィール設定', edit_profile_path, class:'hover:text-yellow-400' %></li>
       </ul>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,12 +10,14 @@
     <ul id="menu" class="fixed top-0 left-0 z-0 w-full bg-point text-center font-bold translate-x-full transition ease-linear">
       <li class="p-1 sm:p-3"><%= link_to t('header.post_index'), posts_path, class: 'hover:text-gray-500' %></li>
       <li class="p-1 sm:p-3"><%= link_to t('header.create_post'), new_post_path, class: 'hover:text-gray-500' %></li>
+      <li class="p-1 sm:p-3"><%= link_to t('header.create_appetizer'), new_appetizer_path, class: 'hover:text-gray-500' %></li>
       <li class="p-1 sm:p-3"><%= link_to t('header.my_page'), profile_path, class: 'hover:text-gray-500' %></li>
       <li class="p-1 sm:p-3"><%= link_to t('header.logout'), logout_path, data: { turbo_method: :delete }, class: 'hover:text-gray-500' %></li>
     </ul>
     <div class="space-x-14 items-center text-lg font-bold md:flex hidden md:block">
       <%= link_to t('header.post_index'), posts_path, class: 'hover:text-gray-500' %>
       <%= link_to t('header.create_post'), new_post_path, class: 'hover:text-gray-500' %>
+      <%= link_to t('header.create_appetizer'), new_appetizer_path, class: 'hover:text-gray-500' %>
       <div class="dropdown dropdown-hover">
         <% if current_user.avatar? %>
           <%= image_tag current_user.avatar.url, class:"rounded-[10px] w-10 h-10" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,5 +18,6 @@
   <% end %>
   <div class="mt-10">
     <%= link_to '過去の投稿一覧を見る', user_posts_path(@user), class: 'hover:text-yellow-400 hover:border-yellow-400 border-b border-gray-500' %>
+    <%= link_to 'AI組合せを見る', user_appetizers_path(@user), class: 'hover:text-yellow-400 hover:border-yellow-400 border-b border-gray-500' %>
   </div>
 </div>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -88,3 +88,4 @@ ja:
     create_post: 投稿する
     ai_combination: AI組合せ
     my_page: マイページ
+    create_appetizer: AI組合せ

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -74,6 +74,8 @@ ja:
     edit:
       title: プロフィール設定
   appetizers:
+    index:
+      user_appetizers_title: 組合せ一覧
     new:
       title: AI組合せ
     show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   root 'tops#index'
   resources :users, only: %i[new create show] do
     resources :posts, only: [:index], on: :member
+    resources :appetizers, only: [:index], on: :member
   end
   resources :posts do
     resources :comments, only: %i[create destroy], shallow: true


### PR DESCRIPTION
### 概要
各ユーザーのAI組合せ一覧ページを追加
### 内容
- 各ユーザーのAI組合せ一覧ページの作成
- ヘッダーにリンク追加
- ハンバーガーメニューにリンク追加
- マイページにリンク追加
- プロフィールページにリンク追加
- AI組合せ詳細ページ（回答結果ページ）にリンク追加
close #147 