### PR TITLE
add: OpenaiAPIのエラーハンドリング

### DIFF
--- a/app/controllers/appetizers_controller.rb
+++ b/app/controllers/appetizers_controller.rb
@@ -11,39 +11,22 @@ class AppetizersController < ApplicationController
   end
 
   def create
-    @client = OpenAI::Client.new(access_token: @api_key)
-    build_body(appetizer_params)
-    response = @client.chat(
-      parameters: {
-        model: "gpt-4-turbo",
-        messages: [{ role: "user", content: @query }]
-      }
-    )
-
-    # APIからの回答を取得
-    full_response = response.dig("choices", 0, "message", "content")
-
-    # 回答からおつまみの名前と解説を抽出
-    if full_response && match = full_response.match(/おつまみ:\s*(.+?)\s*解説:\s*(.+)/)
-      appetizer_name = match[1].strip
-      appetizer_description = match[2].strip
-      @appetizer = current_user.appetizers.new(
-        name: appetizer_name,
-        description: appetizer_description,
-        alcohol_id: appetizer_params[:alcohol_id],
-        base_ingredient_id: appetizer_params[:base_ingredient_id],
-        sub_ingredient_id: appetizer_params[:sub_ingredient_id],
-        accent_ingredient_id: appetizer_params[:accent_ingredient_id]
-      )
-      if @appetizer.save
+    @appetizer = current_user.appetizers.build(appetizer_params)
+    begin
+      service = CreateAppetizerService.new(@appetizer, @api_key)
+      if service.call
         redirect_to appetizer_path(@appetizer), notice: "回答結果を取得しました"
       else
         flash.now[:alert] = "回答結果を取得できませんでした"
         render 'new', status: :unprocessable_entity
       end
-    else
-      flash.now[:alert] = "回答結果を取得できませんでした"
-      render 'new', status: :unprocessable_entity
+    rescue OpenaiAppetizerGenerator::OpenAIError => e
+      flash.now[:alert] = e.message
+      render :new, status: :unprocessable_entity
+    rescue StandardError
+      flash.now[:alert] = "予期せぬエラーが発生しました。もう一度お試しいただくか、管理者までお問い合わせください。"
+      @selected_genres = AlcoholGenre.where(genre: ["ビール", "焼酎", "日本酒", "ウイスキー", "ブランデー", "ワイン", "梅酒", "サワー", "酎ハイ"])
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -52,27 +35,6 @@ class AppetizersController < ApplicationController
   end
 
   private
-
-  def build_body(input)
-    alcohol = Alcohol.find(input[:alcohol_id])
-    base_ingredient = Ingredient.find(input[:base_ingredient_id])
-    sub_ingredient = Ingredient.find(input[:sub_ingredient_id])
-    accent_ingredient = Ingredient.find(input[:accent_ingredient_id])
-
-    @query = "#{alcohol.name}に合うおつまみの名前と解説を、以下の食材を使って1つ提案してください。
-
-    # 食材
-    #{base_ingredient.name}
-    #{sub_ingredient.name}
-    #{accent_ingredient.name}
-
-    # 出力フォーマット
-    おつまみ:おつまみの名前
-    解説:おつまみの解説
-
-    # 条件
-    300トークン以内で出力"
-  end
 
   def appetizer_params
     params.require(:appetizer).permit(:alcohol_id, :base_ingredient_id, :sub_ingredient_id, :accent_ingredient_id)

--- a/app/services/create_appetizer_service.rb
+++ b/app/services/create_appetizer_service.rb
@@ -1,0 +1,33 @@
+class CreateAppetizerService
+  def initialize(appetizer, api_key)
+    @appetizer = appetizer
+    @api_key = api_key
+  end
+
+  def call
+    service = OpenaiAppetizerGenerator.new(@appetizer, @api_key)
+    response = service.call
+    process_response(response)
+  end
+
+  private
+
+  def process_response(response)
+    # AIの回答からおつまみの名前と解説を抽出
+    response && match = response.match(/おつまみ:\s*(.+?)\s*解説:\s*(.+)/)
+    appetizer_name = match[1].strip
+    appetizer_description = match[2].strip
+    # 抽出したデータがすべて存在するかチェック
+    if appetizer_name.blank? || appetizer_description.blank?
+      return false # 抽出したデータがすべて存在しなければ失敗を返す
+    else
+      ActiveRecord::Base.transaction do
+        # 抽出したデータを@appetizerに保存
+        @appetizer.name = appetizer_name
+        @appetizer.description = appetizer_description
+        @appetizer.save! #save! を使用して明示的に例外を発生
+      end
+      true # 保存が成功した場合、trueを返す
+    end
+  end
+end

--- a/app/services/openai_appetizer_generator.rb
+++ b/app/services/openai_appetizer_generator.rb
@@ -1,0 +1,75 @@
+class OpenaiAppetizerGenerator
+  # 仮想のOpenAIクライアントライブラリの例外クラスを定義
+  class OpenAIError < StandardError; end
+
+  def initialize(appetizer, api_key)
+    @appetizer = appetizer
+    @api_key = api_key
+  end
+
+  def call
+    @client = OpenAI::Client.new(access_token: @api_key)
+    begin
+      build_body(@appetizer)
+      response = @client.chat(
+        parameters: {
+          model: "gpt-4-turbo",
+          messages: [{ role: "user", content: @query }]
+        }
+      )
+      # レスポンスが問題なく返ってきているかをチェック
+      if response.key?('choices') && response['choices'].any?
+        response.dig('choices', 0, 'message', 'content')
+      else
+        raise OpenAIError, "予期せぬレスポンス形式です。"
+      end
+    rescue Faraday::ClientError => e
+      handle_faraday_error(e)
+    rescue Faraday::ServerError => e
+      handle_faraday_error(e)
+    rescue Faraday::Error => e
+      raise OpenAIError, "通信エラーが発生しました: #{e.message}"
+    end
+  end
+
+  def handle_faraday_error(e)
+    status = e.response[:status]
+    case status
+    when 400
+      raise OpenAIError, "リクエストが不正です。入力内容を確認してください。"
+    when 401
+      raise OpenAIError, "認証に失敗しました。管理者にお問い合わせ下さい。"
+    when 403..404
+      raise OpenAIError, "リクエスト先のページが存在しません。URLを確認して下さい。"
+    when 408
+      raise OpenAIError, "リクエストがタイムアウトしました。しばらくしてから再試行してください。"
+    when 500..599
+      raise OpenAIError, "サーバー側の問題が発生しました。しばらくしてから再試行してください。"
+    else
+      raise OpenAIError, "予期せぬエラーが発生しました。ステータスコード: #{status}"
+    end
+  end
+
+  private
+
+  def build_body(input)
+    alcohol = Alcohol.find(input.alcohol_id)
+    base_ingredient = Ingredient.find(input.base_ingredient_id)
+    sub_ingredient = Ingredient.find(input.sub_ingredient_id)
+    accent_ingredient = Ingredient.find(input.accent_ingredient_id)
+    # APIに渡す回答内容、条件を指定
+    @query = "#{alcohol.name}に合うおつまみの名前と解説を、以下の食材を使って1つ提案してください。
+
+    # 食材
+    #{base_ingredient.name}
+    #{sub_ingredient.name}
+    #{accent_ingredient.name}
+
+    # 出力フォーマット
+    おつまみ:おつまみの名前
+    解説:おつまみの解説
+
+    # 条件
+    300トークン以内で出力"
+  end
+end


### PR DESCRIPTION
### 概要
OpenaiAPIのエラーに対してのエラーハンドリングを追加

### 内容
- appetizers_controllerのcreateアクションを一部サービスオブジェクトに移動
- create_appetizer_service（openai_appetizer_generatorの呼び出し、APIのレスポンスを成形・保存）を追加
- openai_appetizer_generator（OpenaiAPIの呼び出し、レスポンス内容を指定、エラーの捕捉）を追加

close #154 