### PR TITLE
add: ログイン保持機能

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,7 +4,7 @@ class UserSessionsController < ApplicationController
   def new; end
 
   def create
-    @user = login(params[:email], params[:password])
+    @user = login(params[:email], params[:password], params[:remember_me])
     if @user
       redirect_to root_path, notice: t('.success')
     else
@@ -14,6 +14,8 @@ class UserSessionsController < ApplicationController
   end
 
   def destroy
+    remember_me!
+    forget_me!
     logout
     redirect_to root_path, status: :see_other, notice: t('.success')
   end

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -10,6 +10,10 @@
       <%= f.label :password %>
       <%= f.password_field :password, class: 'input border-gray-400 w-full' %>
     </div>
+    <div class="flex items-center mb-5">
+      <%= check_box_tag :remember_me, params[:remember_me], true, class: "toggle" %>
+      <span class="pl-5">次回から自動ログイン</span>
+    </div>
     <div class="mb-5">
       <%= link_to t('.password_forget'), new_password_reset_path, class: 'underline hover:text-yellow-400' %>
     </div>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:reset_password]
+Rails.application.config.sorcery.submodules = [:reset_password, :remember_me]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -226,7 +226,7 @@ Rails.application.config.sorcery.configure do |config|
   # config.line.bot_prompt = "normal"
   # config.line.user_info_mapping = {name: 'displayName'}
 
-  
+
   # For information about Discord API
   # https://discordapp.com/developers/docs/topics/oauth2
   # config.discord.key = "xxxxxx"
@@ -319,7 +319,7 @@ Rails.application.config.sorcery.configure do |config|
     # How long in seconds the session length will be
     # Default: `60 * 60 * 24 * 7`
     #
-    # user.remember_me_for =
+    user.remember_me_for = 1209600
 
     # When true, sorcery will persist a single remember me token for all
     # logins/logouts (to support remembering on multiple browsers simultaneously).

--- a/db/migrate/20240510044005_sorcery_remember_me.rb
+++ b/db/migrate/20240510044005_sorcery_remember_me.rb
@@ -1,0 +1,8 @@
+class SorceryRememberMe < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :remember_me_token, :string, default: nil
+    add_column :users, :remember_me_token_expires_at, :datetime, default: nil
+
+    add_index :users, :remember_me_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_21_233740) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_10_044005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -110,7 +110,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_21_233740) do
     t.integer "access_count_to_reset_password_page", default: 0
     t.string "avatar"
     t.text "profile"
+    t.string "remember_me_token"
+    t.datetime "remember_me_token_expires_at"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
### 概要
ログイン保持機能を追加

### 内容
- remember_meサブモジュールを使用
- sorcery.rbにセッション期間を設定
- ログインページに、ログイン保持の有無を設定するトグルを追加
close #172 