### PR TITLE
fix: 投稿一覧ページのレイアウト崩れ修正

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -7,7 +7,7 @@
       </div>
       <%= l post.created_at, format: :long %>
     </div>
-    <div class="flex items-center justify-center w-full">
+    <div class="flex items-center justify-center w-full h-80 overflow-hidden">
       <%= display_post_image(post) %>
     </div>
     <div class="flex justify-between">

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,7 +6,6 @@ CarrierWave.configure do |config|
     config.storage :fog
     config.fog_provider = 'fog/aws'
     config.fog_directory  = 'sakananet' # 作成したバケット名
-    config.asset_host = 'https://sakananet.s3.ap-northeast-1.amazonaws.com'
     config.fog_credentials = {
       provider: 'AWS',
       aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],


### PR DESCRIPTION
### 概要
投稿一覧ページのレイアウト崩れを修正

### 内容
- 投稿一覧ページの各カード内の画像表示部分の高さを指定
- 指定した高さを超える場合は、自動的に切り取るように変更
close #181 