### PR TITLE
各所修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,6 @@ class ApplicationController < ActionController::Base
   end
 
   def store_return_to
-    session[:return_to] = request.url if request.get?
+    session[:forwarding_url] = request.original_url if request.get?
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,4 @@
 class ProfilesController < ApplicationController
-  skip_before_action :store_return_to, only: :show
   before_action :set_user, only: %i[show edit update]
 
   def show; end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -5,10 +5,11 @@ class UserSessionsController < ApplicationController
   def new; end
 
   def create
+    forwarding_url = session[:forwarding_url]
+    reset_session
     @user = login(params[:email], params[:password], params[:remember_me])
     if @user
-      redirect_to(session[:return_to] || root_path, notice: t('.success'))
-      session[:return_to] = nil
+      redirect_to(forwarding_url || root_path, notice: t('.success'))
     else
       flash.now[:alert] = t('.failure')
       render :new, status: :unprocessable_entity

--- a/app/views/appetizers/show.html.erb
+++ b/app/views/appetizers/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="mx-auto w-5/6 max-w-screen-sm border shadow-lg bg-amber-50 rounded-[10px] mt-20 p-3">
+<div class="mx-auto w-5/6 max-w-screen-sm border shadow-lg bg-amber-50 rounded-[10px] mt-20 p-3 mb-20">
   <h1 class="text-lg sm:text-2xl font-bold text-center border-dotted border-b-4 border-yellow-400 mt-5 mb-5"><%= @appetizer.name %></h1>
   <p class="text-sm text-center bg-yellow-400 rounded-[5px] px-1 py-2 mb-5">AIによる回答のため、正確な内容ではない場合があります。予めご了承ください。</p>
   <% if @description.present? %>
@@ -25,22 +25,24 @@
       </div>
     </div>
   <% end %>
-  <div class="flex flex-col md:flex-row items-center mb-10">
+  <div class="flex flex-wrap items-center mb-10">
     <% if logged_in? %>
       <div class="flex justify-center w-full md:w-1/3 mb-10 md:mb-0">
         <%= link_to "https://twitter.com/share?url=#{appetizer_url(@appetizer)}&text=#{ERB::Util.url_encode("「#{@appetizer.alcohol.name}」に合うおつまみは、「#{@appetizer.name}」！\n酒菜ネット | ")}&hashtags=sakananet", target: '_blank', data: { toggle: "tooltip", placement: "bottom" },
-            class: 'bg-slate-950 hover:bg-slate-700 text-white font-bold rounded-full shadow-xl px-5 py-3' do %>
+            class: 'bg-slate-950 hover:bg-slate-700 text-white font-bold rounded-full shadow-xl px-3 py-1 md:px-5 md:py-3' do %>
           <i class="fa-brands fa-x-twitter"></i>で共有する
         <% end %>
       </div>
     <% end %>
-    <div class="flex justify-center w-full md:w-1/3">
-      <%= link_to "#{@appetizer.user.name}の組合せ一覧", user_appetizers_path(@appetizer.user), class: 'bg-point font-bold hover:bg-yellow-400 shadow-xl rounded-full px-5 py-3  mb-10 md:mb-0' %>
+    <div class="flex justify-center w-1/2 md:w-1/3">
+      <%= link_to user_appetizers_path(@appetizer.user), class: 'bg-point font-bold hover:bg-yellow-400 shadow-xl rounded-full px-3 py-1 md:px-5 md:py-3' do %>
+        <i class="fa-solid fa-list mr-1"></i>組合せ一覧
+      <% end %>
     </div>
     <% if logged_in? && current_user.own?(@appetizer) %>
-      <div class="flex justify-center w-full md:w-1/3">
-        <%= link_to appetizer_path(@appetizer), data: { turbo_method: :delete, turbo_confirm: t('defaults.message.deleted_confirm') }, class: 'bg-gray-400 font-bold hover:bg-red-400 shadow-xl rounded-full px-5 py-3' do %>
-          削除する<i class="fa-regular fa-trash-can fa-lg"></i>
+      <div class="flex justify-center w-1/2 md:w-1/3">
+        <%= link_to appetizer_path(@appetizer), data: { turbo_method: :delete, turbo_confirm: t('defaults.message.deleted_confirm') }, class: 'bg-gray-400 font-bold hover:bg-red-400 shadow-xl rounded-full px-3 py-1 md:px-5 md:py-3' do %>
+          <i class="fa-regular fa-trash-can fa-lg mr-1"></i>削除する
         <% end %>
       </div>
     <% end %>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,4 +1,4 @@
 <h1 class="flex justify-center font-bold text-base sm:text-xl mb-10">この投稿へのコメント</h1>
-<div class="w-full pb-10", id="table-comment">
+<div class="w-full", id="table-comment">
   <%= render comments %>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,5 +1,5 @@
 <div class="w-full lg:w-1/3 md:w-1/2 p-4">
-  <div class="border bg-amber-50 shadow-xl rounded-lg p-4">
+  <div class="border bg-amber-50 shadow-xl rounded-lg p-4 h-full">
     <div class="flex flex-row justify-between">
       <div class="flex flex-row items-center">
         <%= display_user_avatar(post.user) %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,8 +2,11 @@
   <div class="border bg-amber-50 shadow-xl rounded-lg p-4 h-full">
     <div class="flex flex-row justify-between">
       <div class="flex flex-row items-center">
-        <%= display_user_avatar(post.user) %>
-        <%= link_to post.user.name, post.user == current_user ? profile_path : user_path(post.user), class: 'hover:text-yellow-400' %>
+        <%= link_to post.user == current_user ? profile_path : user_path(post.user) do %>
+          <div class="flex items-center hover:text-yellow-400">
+            <%= display_user_avatar(post.user) %><%= post.user.name %>
+          </div>
+        <% end %>
       </div>
       <%= l post.created_at, format: :long %>
     </div>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for q, url: url, class: 'flex flex-wrap w-full justify-center' do |f| %>
+<%= search_form_for q, url: url, class: 'flex flex-wrap justify-center' do |f| %>
   <% if params[:user_id].present? %>
     <%= f.hidden_field :user_id_eq, value: params[:user_id] %>
   <% end %>
@@ -6,17 +6,19 @@
     <%= f.label :title_or_body_cont, 'タイトル・本文' %>
     <%= f.search_field :title_or_body_cont, class: 'border border-gray-400 rounded-lg w-full px-5 py-3', placeholder: 'キーワードを入力' %>
   </div>
-  <div class="w-full sm:w-2/3 lg:w-1/5 mb-5 mx-1">
-    <%= f.label :alcohol_genre_id_eq, 'お酒のジャンル' %>
-    <%= f.collection_select :alcohol_genre_id_eq, AlcoholGenre.all, :id, :genre, { include_blank: '未選択' }, { class: 'border border-gray-400 rounded-lg text-gray-500 w-full px-5 py-3' } %>
+  <div class="flex justify-center sm:w-2/3 lg:w-2/5 mb-5 mx-1">
+    <div class="w-1/2 pr-1">
+      <%= f.label :alcohol_genre_id_eq, 'お酒のジャンル' %>
+      <%= f.collection_select :alcohol_genre_id_eq, AlcoholGenre.all, :id, :genre, { include_blank: '未選択' }, { class: 'border border-gray-400 rounded-lg text-gray-500 w-full px-5 py-3' } %>
+    </div>
+    <div class="w-1/2 pl-1">
+      <%= f.label :alcohol_genre_id_eq, 'おつまみのジャンル' %>
+      <%= f.collection_select :appetizer_genre_id_eq, AppetizerGenre.all, :id, :genre, { include_blank: '未選択' }, { class: 'border border-gray-400 rounded-lg text-gray-500 w-full px-5 py-3' } %>
+    </div>
   </div>
-  <div class="w-full sm:w-2/3 lg:w-1/5 mb-5 mx-1">
-    <%= f.label :alcohol_genre_id_eq, 'おつまみのジャンル' %>
-    <%= f.collection_select :appetizer_genre_id_eq, AppetizerGenre.all, :id, :genre, { include_blank: '未選択' }, { class: 'border border-gray-400 rounded-lg text-gray-500 w-full px-5 py-3' } %>
-  </div>
-  <div class="flex justify-center items-end w-full sm:w-2/3 lg:w-1/5 mb-5 mx-1">
-    <%= button_tag(type: 'submit', class: 'bg-point hover:bg-yellow-400 shadow-xl rounded-full px-20 py-3 h-12 flex justify-center items-center') do %>
-      検索<i class="fa-solid fa-magnifying-glass"></i>
+  <div class="flex justify-center items-end w-full sm:w-2/3 lg:w-1/5 mb-2 md:mb-0 mx-1 items-center">
+    <%= button_tag(type: 'submit', class: 'bg-point hover:bg-yellow-400 shadow-xl rounded-full px-16 py-3 h-12 flex justify-center items-center') do %>
+      検索<i class="fa-solid fa-magnifying-glass ml-1"></i>
     <% end %>
   </div>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,7 +5,7 @@
   </h1>
   <%= render 'search_form', q: @q, url: params[:user_id] ? user_posts_path(params[:user_id]) : posts_path %>
   <% if @posts.present? %>
-    <div class="flex flex-wrap mt-10">
+    <div class="flex flex-wrap md:mt-10">
       <% @posts.each do |post| %>
         <%= render 'post', post: post %>
       <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, @post.title) %>
 <div class="mx-auto w-3/4 lg:w-5/6 max-w-screen-lg">
   <h1 class="text-lg sm:text-2xl font-bold my-20 text-center"><%= t('.title') %></h1>
-  <div class="flex flex-wrap md:justify-between mb-5 lg:pr-10 items-center">
+  <div class="flex flex-wrap md:justify-between mb-10 md:mb-2 lg:pr-10 items-center">
     <div class="flex justify-center w-full lg:w-1/2 lg:p-5">
       <%= image_tag @post.post_image.url, size: '400x300', class:'mb-5' %>
     </div>
@@ -48,7 +48,7 @@
     </div>
   </div>
   <% unless @post.address.blank? %>
-    <div class="flex justify-center mb-5">
+    <div class="flex justify-center mb-10">
       <div id="map" data-latitude="<%= @post.latitude %>" data-longitude="<%= @post.longitude %>" data-address="<%= @post.address %>" style="height: 500px; width: 800px"></div>
     </div>
   <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,8 +9,11 @@
       <div class="border bg-amber-50 shadow-2xl p-4 rounded-lg">
         <div class="flex justify-between items-center mb-3">
           <div class="flex justify-start items-center">
-            <%= display_user_avatar(@post.user) %>
-            <%= link_to @post.user.name, @post.user == current_user ? profile_path : user_path(@post.user), class:'hover:text-yellow-400 text-lg' %>
+            <%= link_to @post.user == current_user ? profile_path : user_path(@post.user), class:'hover:text-yellow-400 text-lg' do %>
+              <div class="flex items-center hover:text-yellow-400 text-lg">
+                <%= display_user_avatar(@post.user) %><%=  @post.user.name %>
+              </div>
+            <% end %>
           </div>
           <% if logged_in? && current_user.own?(@post) %>
             <%= render 'posts/post_actions', post: @post %>

--- a/app/views/tops/_explanation.html.erb
+++ b/app/views/tops/_explanation.html.erb
@@ -61,7 +61,7 @@
   <div class="border bg-amber-50 shadow-xl rounded-lg px-6 py-4 mb-10">
     <div class="flex flex-col xl:flex-row">
       <div class="xl:w-1/2 text-left flex flex-col justify-center xl:pt-10">
-        <%= link_to 'マイページ', login_path, class: 'text-lg font-bold bg-yellow-400 rounded-lg shadow-lg hover:bg-yellow-300 px-4 py-2 mx-auto' %>
+        <%= link_to 'マイページ', profile_path, class: 'text-lg font-bold bg-yellow-400 rounded-lg shadow-lg hover:bg-yellow-300 px-4 py-2 mx-auto' %>
         <div class="text-left py-3 xl:py-10 mx-auto">
           <p>マイページから、過去の投稿一覧、いいねした投稿一覧、AI組合せ一覧、</p>
           <p class="mb-5">プロフィール設定にアクセスできます。</p>
@@ -76,7 +76,11 @@
   <div class="border bg-amber-50 shadow-xl rounded-lg px-6 py-4 mb-10">
     <div class="flex flex-col xl:flex-row">
       <div class="xl:w-1/2 text-left flex flex-col justify-center xl:pt-10">
-        <%= link_to 'AI組合せの回答結果', login_path, class: 'text-lg font-bold bg-yellow-400 rounded-lg shadow-lg hover:bg-yellow-300 px-4 py-2 mx-auto' %>
+        <% if logged_in? %>
+          <%= link_to 'AI組合せの回答結果', user_appetizers_path(current_user), class: 'text-lg font-bold bg-yellow-400 rounded-lg shadow-lg hover:bg-yellow-300 px-4 py-2 mx-auto' %>
+        <% else %>
+          <%= link_to 'AI組合せの回答結果', login_path, class: 'text-lg font-bold bg-yellow-400 rounded-lg shadow-lg hover:bg-yellow-300 px-4 py-2 mx-auto' %>
+        <% end %>
         <div class="text-left py-3 xl:py-10 mx-auto">
           <p>AI組合せの回答結果は、マイページより確認できます。</p>
           <p class="mb-5">お酒、おつまみの組合せ解説、使用材料、作り方が表示されます。</p>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -20,7 +20,10 @@
       <%= image_tag 'top_icon.webp', class: 'rounded-xl border shadow-2xl w-72 h-auto md:w-80 md:h-auto' %>
     </div>
   </div>
-  <p class="text-center text-lg text-gray-700 font-bold md:text-lg pt-5 mb-12">みんなのアイデアで晩酌、飲み会をより豊かに...</p>
+  <div class="flex flex-wrap justify-center">
+    <p class="text-center text-lg text-gray-700 font-bold md:text-lg md:pt-5 md:mb-12">みんなのアイデアで</p>
+    <p class="text-center text-lg text-gray-700 font-bold md:text-lg md:pt-5 mb-10">晩酌、飲み会をより豊かに...</p>
+  </div>
   <div class="flex justify-center items-center">
     <i class="fa-solid fa-angles-down fa-lg pr-2"></i>
     <h1 class="text-xl md:text-2xl font-bold">酒菜ネットの使い方</h1>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -2,10 +2,10 @@
   <div class="flex justify-center items-center flex-col-reverse md:flex-row mt-10 md:mt-40">
     <div class="w-full md:w-1/2 flex flex-col mt-10 md:mt-0">
       <div class="space-y-2">
-        <h1 class="text-xl md:text-4xl font-bold text-center drop-shadow-xl">
+        <h1 class="text-2xl md:text-4xl font-bold text-center drop-shadow-xl">
           酒菜ネットは、お酒&おつまみの
         </h1>
-        <h1 class="text-xl md:text-4xl font-bold text-center drop-shadow-xl">
+        <h1 class="text-2xl md:text-4xl font-bold text-center drop-shadow-xl">
           情報共有サービスです
         </h1>
       </div>
@@ -27,4 +27,20 @@
     <i class="fa-solid fa-angles-down fa-lg pl-2"></i>
   </div>
   <%= render 'explanation' %>
+  <div class="flex flex-wrap mb-14">
+    <div class="w-full md:w-1/3 flex justify-center">
+      <%= link_to new_user_path, class: 'text-lg font-bold bg-yellow-400 rounded-full shadow-lg hover:bg-yellow-300 px-4 py-2 mb-3 md:mb-0' do %>
+        <i class="fa-solid fa-user-plus mr-2"></i>新規登録
+      <% end %>
+    </div>
+    <div class="w-full md:w-1/3 flex justify-center">
+      <%= link_to login_path, class: 'text-lg font-bold bg-yellow-400 rounded-full shadow-lg hover:bg-yellow-300 px-4 py-2 mb-3 md:mb-0' do %>
+        <i class="fa-solid fa-arrow-right-to-bracket mr-2"></i>ログイン
+      <% end %>
+    </div>
+    <div class="w-full md:w-1/3 flex justify-center">
+      <%= link_to posts_path, class: 'text-lg font-bold bg-yellow-400 rounded-full shadow-lg hover:bg-yellow-300 px-4 py-2' do %>
+        <i class="fa-solid fa-list mr-2"></i>みんなの投稿
+      <% end %>
+    </div>
 </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "app_production"
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = {protocol: 'https', host: 'sakananet.onrender.com'}
+  config.action_mailer.default_url_options = {protocol: 'https', host: 'sakana-net.com'}
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.delivery_method = :smtp

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -34,7 +34,7 @@ ja:
       success: ログアウトしました
   users:
     new:
-      title: ユーザー登録
+      title: 新規登録
     create:
       success: ユーザー登録が完了しました
       failure: ユーザー登録に失敗しました


### PR DESCRIPTION
- 投稿一覧ページで、文字数の多い投稿があると、高さが不揃いになる問題を修正
- AI組合せ詳細ページの下部の余白を修正
- AI組合せ詳細ページのボタン配置修正
- フレンドリーフォワーディングの修正
- パスワードリセットページのリンクを修正
- ユーザー登録→新規登録
- トップページ下部にリンク追加
- トップページのレイアウト調整
- 検索フォームのレイアウト調整
- ユーザーアイコンにリンク追加
- コメントエリア上部の余白調整
